### PR TITLE
Changed `Update` to `Fixed` for fixed time steps.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -174,7 +174,7 @@ impl<S: YoetzSuggestion> Default for YoetzPlugin<S> {
 impl<S: 'static + YoetzSuggestion> Plugin for YoetzPlugin<S> {
     fn build(&self, app: &mut App) {
         app.configure_sets(
-            Update,
+            FixedUpdate,
             (
                 YoetzSystemSet::Suggest,
                 YoetzInternalSystemSet::Think,
@@ -183,7 +183,7 @@ impl<S: 'static + YoetzSuggestion> Plugin for YoetzPlugin<S> {
                 .chain(),
         );
         app.add_systems(
-            Update,
+            FixedUpdate,
             update_advisor::<S>.in_set(YoetzInternalSystemSet::Think),
         );
     }


### PR DESCRIPTION
Maybe the plugin should accept an argument to pick one, but it should still default to `Fixed`.

Recreating PR because [previous](https://github.com/idanarye/bevy-yoetz/pull/1) got spam from some script kiddie. 
