### PR TITLE
fix: YoetzSuggestion enums can now be public

### DIFF
--- a/macros/src/suggestion/suggestion_enum.rs
+++ b/macros/src/suggestion/suggestion_enum.rs
@@ -74,6 +74,7 @@ impl SuggestionEnumData {
         &self,
         variants: &[SuggestionVariantData],
     ) -> Result<TokenStream, Error> {
+        let visibility = &self.visibility;
         let omni_query_name = &self.omni_query_name;
         let strategies = variants.iter().enumerate().map(|(i, variant)| {
             let strategy_field_name = syn::Ident::new(&format!("strategy{i}"), Span::call_site());
@@ -85,7 +86,7 @@ impl SuggestionEnumData {
         Ok(quote! {
             #[derive(bevy::ecs::query::QueryData)]
             #[query_data(mutable)]
-            struct #omni_query_name {
+            #visibility struct #omni_query_name {
                 #(#strategies,)*
             }
         })


### PR DESCRIPTION
I noticed i couldn't make any pub enum with the YoetzSuggestion derive work due to the generated OmniQuery struct always beign private.

I updated the code so that the OmniQuery struct inherits the visibility of the enum.

I believe this fixes #11.